### PR TITLE
Fixing tensorflow error in new version

### DIFF
--- a/AI_Journey_2021_GAN_mastercalss.ipynb
+++ b/AI_Journey_2021_GAN_mastercalss.ipynb
@@ -3310,7 +3310,7 @@
         "\n",
         "        self.add_loss(d_loss_0 + d_loss_1 + 0.25 * g_loss)\n",
         "\n",
-        "        return images_gen\n",
+        "        return tf.zeros(batch_size)\n",
         "\n",
         "\n",
         "gan = GAN()\n",
@@ -3394,7 +3394,7 @@
         "outputId": "582f2670-9585-4003-c18f-94676fddf56b"
       },
       "source": [
-        "gan.fit(data, batch_size=64, epochs=100, callbacks=PlotImgsCallback())"
+        "gan.fit(data, y=np.zeros(len(data)), batch_size=64, epochs=100, callbacks=PlotImgsCallback())"
       ],
       "execution_count": null,
       "outputs": [


### PR DESCRIPTION
The original notebook stopped working due to this update in keras: https://github.com/keras-team/keras/commit/4c281df898e7e842b94c451afc94fc1e5cf3014a#diff-8a7c3fcee7bd990ad745dd02f80c0a3fe8f0bd41cbbdd3bc931635b1fbf2750fR799

Adding a mock model output in `call` and a mock target in `fit` to avoid the assertion.